### PR TITLE
CYTHINF-57 Remove Dummy Bucket

### DIFF
--- a/deploy/dns.template.yml
+++ b/deploy/dns.template.yml
@@ -21,9 +21,6 @@ Parameters:
     Description: The alias target (cname value) to use for the production version of icons.
   
 Resources:
-  DummyBucket:
-    Type: AWS::S3::Bucket
-
   DevRecords:
     Type: AWS::Route53::RecordSetGroup
     Properties:


### PR DESCRIPTION
This removes the dummy bucket that was used for getting the updated stack description to show up.