### PR TITLE
CYTHINF-123 Hotfix: Disallow Public Access to Dirty Files

### DIFF
--- a/deploy/icons.template.yml
+++ b/deploy/icons.template.yml
@@ -13,6 +13,13 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Ref DomainName
+      LifecycleConfiguration:
+        Rules:
+          - Status: Enabled
+            ExpirationInDays: 1
+            TagFilters:
+              - Key: dirty
+                Value: "true"
       CorsConfiguration:
         CorsRules:
           - AllowedMethods:

--- a/deploy/icons.template.yml
+++ b/deploy/icons.template.yml
@@ -28,9 +28,6 @@ Resources:
             AllowedOrigins:
               - "*"
   
-  TestBucket:
-    Type: AWS::S3::Bucket
-  
   BucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:

--- a/deploy/icons.template.yml
+++ b/deploy/icons.template.yml
@@ -38,12 +38,17 @@ Resources:
           - Effect: Allow
             Principal:
               CanonicalUser: !GetAtt CloudfrontIdentity.S3CanonicalUserId
-            Action: 
-              - s3:ListBucket
-              - s3:GetObject
-            Resource: 
-              - !Sub arn:aws:s3:::${Bucket}
-              - !Sub arn:aws:s3:::${Bucket}/*
+            Action: s3:ListBucket
+            Resource: !Sub arn:aws:s3:::${Bucket}
+          - Effect: Allow
+            Principal:
+              CanonicalUser: !GetAtt CloudfrontIdentity.S3CanonicalUserId
+            Action: s3:GetObject
+            Resource: !Sub arn:aws:s3:::${Bucket}/*
+            Condition:
+              StringNotEquals:
+                s3:ExistingObjectTag/dirty: "true"
+            
 
   CloudfrontIdentity:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity

--- a/src/html/pages/about.html
+++ b/src/html/pages/about.html
@@ -1,0 +1,5 @@
+{{include:header}}
+
+<p>Test about page</p>
+
+{{include:footer}}

--- a/src/html/pages/about.html
+++ b/src/html/pages/about.html
@@ -1,5 +1,0 @@
-{{include:header}}
-
-<p>Test about page</p>
-
-{{include:footer}}


### PR DESCRIPTION
This disallows the canonical s3 user cloudfront uses to access files that are marked as dirty.  This should prevent public accessibility of files that have meant to be deleted