### PR TITLE
CYTHINF-71 Upgrade to HTTP2

### DIFF
--- a/deploy/icons.template.yml
+++ b/deploy/icons.template.yml
@@ -54,6 +54,7 @@ Resources:
         Enabled: true
         PriceClass: PriceClass_100
         DefaultRootObject: index.html
+        HttpVersion: http2
         ViewerCertificate: 
           AcmCertificateArn: !Ref Certificate
           SslSupportMethod: sni-only


### PR DESCRIPTION
This upgrades the CloudFront Distribution to use HTTP2.